### PR TITLE
Fixed PostResource.java which was missing a @Context annotation

### DIFF
--- a/mp-jpa/src/main/java/com/example/PostResource.java
+++ b/mp-jpa/src/main/java/com/example/PostResource.java
@@ -74,7 +74,7 @@ public class PostResource {
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    public Response savePost(@Valid Post post, UriInfo uriInfo) {
+    public Response savePost(@Valid Post post, @Context UriInfo uriInfo) {
         var saved = this.posts.save(Post.of(post.getTitle(), post.getContent()));
         var createdUri = uriInfo.getBaseUriBuilder()
                 .path("/posts/{id}")


### PR DESCRIPTION
This does not fix the `EntityManagerFactory` initialization problem, but it does repair your `PostResource` class.

Signed-off-by: Laird Nelson <ljnelson@gmail.com>