### PR TITLE
Added an observer method to work around Helidon issue 3009 until it is fixed properly

### DIFF
--- a/mp-jpa/src/main/java/com/example/DataInitializer.java
+++ b/mp-jpa/src/main/java/com/example/DataInitializer.java
@@ -1,12 +1,17 @@
 package com.example;
 
-
+import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Destroyed;
 import javax.enterprise.context.Initialized;
 import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
+import javax.persistence.EntityManagerFactory;
 import java.util.logging.Logger;
+
+import static javax.interceptor.Interceptor.Priority.LIBRARY_BEFORE;
 
 @ApplicationScoped
 public class DataInitializer {
@@ -24,6 +29,14 @@ public class DataInitializer {
         this.posts.save(second);
 
         this.posts.findAll().forEach(p -> System.out.println("Post:" + p));
+    }
+
+    // See https://github.com/oracle/helidon/issues/3009 and https://github.com/oracle/helidon/issues/2630
+    private static void helidon3009Workaround(@Observes @Initialized(ApplicationScoped.class) @Priority(LIBRARY_BEFORE) Object init,
+                                              @Any Instance<EntityManagerFactory> emfProxies) {
+        for (EntityManagerFactory emfProxy : emfProxies) {
+            emfProxy.isOpen();
+        }
     }
 
     void onStop(@Observes @Destroyed(ApplicationScoped.class) Object init) {


### PR DESCRIPTION
This workaround ensures `EntityManagerFactory` client proxies are eagerly initialized.

Signed-off-by: Laird Nelson <ljnelson@gmail.com>